### PR TITLE
Add simpler version of missing equals method

### DIFF
--- a/src/Product.php
+++ b/src/Product.php
@@ -175,6 +175,7 @@ class Product
         ];
     }
 
+    // @phpstan-ignore-next-line
     public function equals($object): bool
     {
         return ($object instanceof Product) &&

--- a/src/Product.php
+++ b/src/Product.php
@@ -175,6 +175,13 @@ class Product
         ];
     }
 
+    public function equals($object): bool
+    {
+        return ($object instanceof Product) &&
+            ($this->id === $object->id) &&
+            $this->toJson() === $object->toJson();
+    }
+
     /**
      * @return int|null
      */

--- a/tests/Unit/Product/ProductTest.php
+++ b/tests/Unit/Product/ProductTest.php
@@ -7,9 +7,6 @@ use SnowIO\BrightpearlDataModel\Product;
 
 class ProductTest extends TestCase
 {
-    /**
-     * @return array
-     */
     private function getJsonData(): array
     {
         return [
@@ -153,9 +150,6 @@ class ProductTest extends TestCase
         ];
     }
 
-    /**
-     * @return void
-     */
     public function testFromJsonToJson()
     {
         $data = $this->getJsonData();
@@ -163,9 +157,6 @@ class ProductTest extends TestCase
         self::assertEquals($data, $product->toJson());
     }
 
-    /**
-     * @return void
-     */
     public function testWithers()
     {
         $identity = Product\Identity::create()
@@ -300,9 +291,6 @@ class ProductTest extends TestCase
         self::assertEquals($this->getJsonData(), $product->toJson());
     }
 
-    /**
-     * @return void
-     */
     public function testGetters()
     {
         $data = $this->getJsonData();
@@ -422,5 +410,17 @@ class ProductTest extends TestCase
         self::assertEquals("Warehouse sale", $product->getWarehousePopupMessage());
         self::assertEquals(456, $product->getVersion());
         self::assertEquals(["custom field 1", "custom field 2", "custom field 3"], $product->getCustomFields());
+    }
+
+    public function testEquals()
+    {
+        $data = $this->getJsonData();
+        $product1 = Product::fromJson($data);
+        $product2 = Product::fromJson($data);
+        self::assertTrue($product1->equals($product2));
+
+        $product1 = Product::fromJson($data);
+        $product2 = Product::fromJson($data)->withId(1);
+        self::assertFalse($product1->equals($product2));
     }
 }


### PR DESCRIPTION
Add missing method to compare two data models. Simplified version since a proper one will be fixed by Dan.